### PR TITLE
chore(deps): Pin github workflow deps

### DIFF
--- a/.github/workflows/dependabot-approve-and-request-merge.yml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yml
@@ -13,6 +13,6 @@ jobs:
 
     if: github.actor == 'dependabot[bot]'
     steps:
-    - uses: contentful/github-auto-merge@v1
+    - uses: contentful/github-auto-merge@84260b2498c23b699bf84a3c9c3ee13b14a3386a # main
       with:
         VAULT_URL: ${{ secrets.VAULT_URL }}

--- a/.github/workflows/eslint-tsc.yml
+++ b/.github/workflows/eslint-tsc.yml
@@ -8,9 +8,11 @@ on: [pull_request]
 jobs:
  eslint-tsc:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           
@@ -19,7 +21,7 @@ jobs:
         id: nvm
 
       - name: Use Node.js (.nvmrc)
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
@@ -28,7 +30,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Use Yarn cache
-        uses: actions/cache@v3.2.3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
## Purpose of PR
Implement Github best practices from upstream: 

* Add workflow permissions
* Pin Github dependencies to commit SHAs

<!-- If this has a larger context, uncomment and put it here
_Purpose_

Why do we introduce this change? What problem do we solve? What is the
story/background for it?
-->



<!-- # If there is deployment related information, uncomment and put it here 
## Deployment & Risks

* [ ] There is a migration necessary for this to work
* [ ] There is a dependent PR that needs to be deployed first
* [ ] I have read the relevant `readme.md` file(s)
* [ ] Tests are added/updated/not required
* [ ] Tests are passing
* [ ] Usage notes are added/updated/not required
* [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
* [ ] Doesn't contain any sensitive information
-->

## Security

_Before you click Merge, take a step back and think how someone could break the [Confidentiality, Integrity and Availability](https://docs.google.com/presentation/d/1YdFlYBLnbNoiSAMOKjopiF4u34StXTK2qYdOLkMsEKo/edit?usp=sharing) of the code you've just written. Are secrets secret? Is there any sensitive information disclosed in logs or error messages? How does your code ensure that information is accurate, complete and protected from modification? Will your code keep Contentful working and functioning?_

<!-- # Reminders
* [Write good pull requests!](https://seesparkbox.com/foundry/github_pull_requests_for_everyone) 👼
* [Be a good reviewer!](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews) 🧐
-->
